### PR TITLE
Support Rocky Linux and add workarounds for issues with OFED installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please see `defaults/main.yml`.
 * `ofed_repository_url` Gives a URL to the repository holding the OFED driver packages. Defaults to the [Mellanox public package repository](https://linux.mellanox.com/public/repo/mlnx_ofed)
 * `ofed_version` Specifies the OFED driver version to be installed, default is `latest`
 * `ofed_target_release` Specifies the Linux distribution for the install of the OFED drivers, default is `rhel7.8`
- 
+
 # Dependencies
 
 None
@@ -53,6 +53,64 @@ This should skip the kernel updates:
       tasks:
         - include_role: stackhpc.ofed
 ```
+
+## Packaged dependency conflicts
+
+If the OFED drivers fail to install with conflicts over `libibverbs` with an error similar to the following:
+
+```
+"Depsolve Error occured: \n Problem: cannot install both libibverbs-55mlnx37-1.55103.x86_64 and libibverbs-35.0-1.el8.x86_64\n  - package perftest-4.5-1.el8.x86_64 requires libefa.so.1()(64bit), but none of the providers can be installed\n  - package perftest-4.5-1.el8.x86_64 requires libefa.so.1(EFA_1.1)(64bit), but none of the providers can be installed\n  - cannot install the best candidate for the job"
+```
+
+This can be resolved from the command line by passing `--nobest` to `yum` or `dnf`, or with this playbook with the `ofed_nobest` variable.
+
+```
+    - hosts: servers
+      vars:
+        ofed_nobest: true
+      tasks:
+        - include_role: stackhpc.ofed
+```
+
+## Failure backing up Grub config
+
+The kernel update updates the grub configuration to include the new kernel modules, however if a host is missing either grub configuration file `/etc/grub2.cfg` or `/etc/grub2-efi.cfg` this task can fail. The backup can be disabled with the `ofed_grub_backup` variable.
+
+**NOTE:** It's recommended to test that the host successfully boots with the OFED Kernel Modules first before disabling the config backup, as this setting destroys the previous configuration.
+
+```
+    - hosts: servers
+      vars:
+        ofed_grub_backup: false
+      tasks:
+        - include_role: stackhpc.ofed
+```
+## Incorrect Kernel Modules
+
+On installing the Mellanox OFED Drivers, the `openibd` daemon may not start with the following errors:
+
+```
+openibd: ERROR: Module mlx5_ib belong to kernel-modules which is not a part of MLNX_OFED, skipping
+openibd: ERROR: Module mlx5_core belong to kernel-core which is not a part of MLNX_OFED, skipping
+openibd: ERROR: Module ib_umad belong to kernel-modules which is not a part of MLNX_OFED, skipping
+openibd: ERROR: Module ib_uverbs belong to kernel-modules which is not a part of MLNX_OFED, skipping
+openibd: ERROR: Module ib_ipoib belong to kernel-modules which is not a part of MLNX_OFED, skipping
+openibd: ERROR: Module rdma_cm belong to kernel-modules which is not a part of MLNX_OFED, skipping
+openibd: ERROR: Module rdma_ucm belong to kernel-modules which is not a part of MLNX_OFED, skipping
+```
+
+This can be due to the kernel modules included in the packages from the repository not matching the kernel, while it is recommended that the [kernel modules be recompiled to match the kernel](https://docs.nvidia.com/networking/display/MLNXOFEDv531001/Installing+Mellanox+OFED#InstallingMellanoxOFED-additionalinstallationproceduresAdditionalInstallationProcedures) and provided via a local package repositry there is a workaround by enabling `FORCE_MODE` and disabling `RDMA_UCM_LOAD` in `/etc/infiniband/openib.conf`. The role can implement this with the following variables:
+
+```
+    - hosts: servers
+      vars:
+        ofed_manage_openib_conf: true
+        ofed_force_mode: true
+        ofed_rdma_ucm_load: false
+      tasks:
+        - include_role: stackhpc.ofed
+```
+
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,8 @@ ofed_nobest: false
 
 # Backup grub files?
 ofed_grub_backup: true
+
+# Manage settings in /etc/infiniband/openib.conf
+ofed_manage_openib_conf: false
+ofed_force_mode: false
+ofed_rdma_ucm_load: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,6 @@ ofed_repo_name: "{{ ofed_repo_file | basename }}"
 
 # Package installation options
 ofed_nobest: false
+
+# Backup grub files?
+ofed_grub_backup: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,6 @@ ofed_repo_file: "{{ ofed_repository_url}}/{{ofed_version}}/{{ofed_target_release
 
 # Name of repository file
 ofed_repo_name: "{{ ofed_repo_file | basename }}"
+
+# Package installation options
+ofed_nobest: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,8 @@
 ---
 # handlers file for ofed
+- name: Restart OpenIB daemon
+  service:
+    name: openibd
+    state: restarted
+  become: true
+  listen: restart_openibd

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,8 @@ galaxy_info:
 
   license: Apache
 
-  min_ansible_version: 2.4
+  # Minimum version of Ansible that supports Rocky Linux
+  min_ansible_version: 2.11
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,8 @@
 
 - name: Replace current grub config
   copy:
-    backup: true
+    # This fails if a file doesn't exist to be backed up so set ofed_grub_backup to false
+    backup: "{{ ofed_grub_backup }}"
     # /etc/grub2.cfg -> ../boot/grub2/grub.cfg
     follow: true
     content: "{{ grub_mkconfig_result.stdout }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
   yum:
     name: "@Infiniband Support"
     state: present
+    nobest: "{{ ofed_nobest | bool }}"
   become: true
   when:
     - ansible_os_family == "RedHat"
@@ -37,6 +38,7 @@
   dnf:
     name: "@Infiniband Support"
     state: present
+    nobest: "{{ ofed_nobest }}"
   become: true
   when:
     - ansible_os_family == "RedHat"
@@ -60,7 +62,7 @@
 
 - name: Make grub default to supported kernel
   # NOTE: This affects config generation so put it before
-  command: grub2-set-default 'CentOS Linux ({{ supported_kernel.stdout }}) {{ ansible_distribution_major_version }} (Core)'
+  command: grub2-set-default '{{ ansible_distribution }} Linux ({{ supported_kernel.stdout }}) {{ ansible_distribution_major_version }} (Core)'
   changed_when: false
   become: true
   when: ofed_update_kernel | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,7 @@
 
 - name: Replace current grub config
   copy:
-    # This fails if a file doesn't exist to be backed up so set ofed_grub_backup to false
+    # This fails if a file doesn't exist to be backed up, so need to be able to set ofed_grub_backup to false
     backup: "{{ ofed_grub_backup }}"
     # /etc/grub2.cfg -> ../boot/grub2/grub.cfg
     follow: true
@@ -88,3 +88,21 @@
   with_items:
     - /etc/grub2.cfg
     - /etc/grub2-efi.cfg
+
+- name: Configure OpenIB
+  template:
+    src: templates/etc/infiniband/openib.conf.j2
+    dest: /etc/infiniband/openib.conf
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+  notify: restart_openibd
+  when: ofed_manage_openib_conf | bool
+
+- name: Check state of OpenIB daemon
+  service:
+    name: openibd
+    state: started
+    enabled: true
+  become: true

--- a/templates/etc/infiniband/openib.conf.j2
+++ b/templates/etc/infiniband/openib.conf.j2
@@ -1,0 +1,65 @@
+#jinja2:lstrip_blocks: True
+# Managed by Ansible, changes may be overwritten
+# StackHPC mlnx_ofed Ansible role: https://github.com/stackhpc/ansible-role-ofed
+
+# Start HCA driver upon boot
+ONBOOT=yes
+
+# Allow calling the service script with the option 'stop' for unloading the driver stack.
+# This flag should be disabled when the OS root file system is on remote storage.
+ALLOW_STOP=yes
+
+# Run the service script with force mode to enable loading the driver stack even
+# if the available modules were not installed by MLNX_OFED package.
+FORCE_MODE={% if ofed_force_mode %}yes{% else %}no{% endif %}
+
+# Node description
+NODE_DESC=$(hostname -s)
+
+# Wait for NODE_DESC_TIME_BEFORE_UPDATE sec before node_desc update
+NODE_DESC_TIME_BEFORE_UPDATE=20
+
+# Max time in seconds to wait for node's hostname to be set
+NODE_DESC_UPDATE_TIMEOUT=120
+
+# Seconds to sleep after openibd start finished and before releasing the shell
+POST_START_DELAY=0
+
+# Run /usr/sbin/mlnx_affinity
+RUN_AFFINITY_TUNER=no
+
+# Run /usr/sbin/mlnx_tune
+RUN_MLNX_TUNE=no
+
+# Load E_IPoIB
+LOAD_EIPOIB=no
+
+# Increase ib_mad thread priority
+RENICE_IB_MAD=no
+
+# Run sysctl performance tuning script
+RUN_SYSCTL=no
+
+# Enable FW debug tracer - set to no to disable, default = yes
+ENABLE_FW_TRACER=yes
+
+# Set MAC address of PF via ECPF
+# SMARTNIC_PF_MAC_CONF="[<bdf1>-<MAC1>] [<bdf2>-<MAC2>] ..."
+# E.g.:
+# SMARTNIC_PF_MAC_CONF="0000:03:00.0-c4:8a:07:a5:29:70 0000:03:00.1-c4:8a:07:a5:29:71"
+# Load UMAD module
+UMAD_LOAD=yes
+# Load UVERBS module
+UVERBS_LOAD=yes
+# Load RDMA_CM module
+RDMA_CM_LOAD=yes
+# Load RDMA_UCM module
+RDMA_UCM_LOAD={% if ofed_rdma_ucm_load %}yes{% else %}no{% endif %}
+# Load MLX5 modules
+MLX5_LOAD=yes
+# Load IPoIB
+IPOIB_LOAD=yes
+# Enable IPoIB Connected Mode
+SET_IPOIB_CM=auto
+# Load SRP module
+SRP_LOAD=no


### PR DESCRIPTION
This is likely to trigger a major version as Rocky Linux requires Ansible 2.11 or later as previous versions classify Rocky as an Unknown distribution.

Included in this merge request:
- `ofed_grub_backup` to disable/enable backing up grub config, as the backups fail if the files do not exist
- `ofed_nobest` to add the `--nobest` flag to package installs when there's a dependency conflict with `libibverbs`
- Checks and manages the `openibd` service
- Basic configuration of `/etc/infiniband/openib.conf` to work-around kernel module issues
- Documentation for these things.